### PR TITLE
Only mirror based on label selector

### DIFF
--- a/kube/endpoints_watcher.go
+++ b/kube/endpoints_watcher.go
@@ -21,32 +21,34 @@ var (
 type EndpointsEventHandler = func(eventType watch.EventType, old *v1.Endpoints, new *v1.Endpoints)
 
 type EndpointsWatcher struct {
-	client       kubernetes.Interface
-	resyncPeriod time.Duration
-	stopChannel  chan struct{}
-	store        cache.Store
-	controller   cache.Controller
-	eventHandler EndpointsEventHandler
+	client        kubernetes.Interface
+	resyncPeriod  time.Duration
+	stopChannel   chan struct{}
+	store         cache.Store
+	controller    cache.Controller
+	eventHandler  EndpointsEventHandler
+	labelSelector string
 }
 
-func NewEndpointsWatcher(client kubernetes.Interface, resyncPeriod time.Duration, handler EndpointsEventHandler) *EndpointsWatcher {
+func NewEndpointsWatcher(client kubernetes.Interface, resyncPeriod time.Duration, handler EndpointsEventHandler, labelSelector string) *EndpointsWatcher {
 	return &EndpointsWatcher{
-		client:       client,
-		resyncPeriod: resyncPeriod,
-		stopChannel:  make(chan struct{}),
-		eventHandler: handler,
+		client:        client,
+		resyncPeriod:  resyncPeriod,
+		stopChannel:   make(chan struct{}),
+		eventHandler:  handler,
+		labelSelector: labelSelector,
 	}
 }
 
 func (ew *EndpointsWatcher) Init() {
 	listWatch := &cache.ListWatch{
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-			// "" will get endpoints from all namespaces
-			return ew.client.CoreV1().Endpoints("").List(options)
+			options.LabelSelector = ew.labelSelector
+			return ew.client.CoreV1().Endpoints(metav1.NamespaceAll).List(options)
 		},
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-			// "" will get endpoints from all namespaces
-			return ew.client.CoreV1().Endpoints("").Watch(options)
+			options.LabelSelector = ew.labelSelector
+			return ew.client.CoreV1().Endpoints(metav1.NamespaceAll).Watch(options)
 		},
 	}
 	eventHandler := cache.ResourceEventHandlerFuncs{

--- a/main.go
+++ b/main.go
@@ -13,10 +13,11 @@ import (
 var (
 	flagKubeConfigPath       = flag.String("kube-config", "", "Path of a kube config file, if not provided the app will try to get in cluster config")
 	flagTargetKubeConfigPath = flag.String("target-kube-config", "", "(required) Path of the target cluster kube config file to mirrot services from")
-	flagLogLevel             = flag.String("log-level", "info", "log level, defaults to info")
+	flagLogLevel             = flag.String("log-level", "info", "Log level, defaults to info")
 	flagResyncPeriod         = flag.Duration("resync-period", 60*time.Minute, "Namespace watcher cache resync period")
-	flagMirrorNamespace      = flag.String("mirror-ns", "", "the namespace to create dummy mirror services in")
-	flagSvcPrefix            = flag.String("svc-prefix", "", "a prefix to apply on all mirrored services names")
+	flagMirrorNamespace      = flag.String("mirror-ns", "", "The namespace to create dummy mirror services in")
+	flagSvcPrefix            = flag.String("svc-prefix", "", "A prefix to apply on all mirrored services names")
+	flagLabelSelector        = flag.String("label-selector", "", "(required) Label of services and endpoints to watch and mirror")
 )
 
 func usage() {
@@ -29,6 +30,10 @@ func main() {
 	flag.Parse()
 
 	if *flagTargetKubeConfigPath == "" {
+		usage()
+	}
+
+	if *flagLabelSelector == "" {
 		usage()
 	}
 
@@ -58,6 +63,7 @@ func main() {
 		watchClient,
 		*flagMirrorNamespace,
 		*flagSvcPrefix,
+		*flagLabelSelector,
 		// Resync will trigger an onUpdate event for everything that is
 		// stored in cache.
 		*flagResyncPeriod,


### PR DESCRIPTION
That will untie services from endpoints and will make this a simple copy paste
service based on existing labels by removing the service validation logic for
endpoints and the filtering based on service type (clusterIP)